### PR TITLE
Fix installation destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ if (APPLE)
     ]] COMPONENT Runtime)
 endif()
 
-install(TARGETS sushi RUNTIME DESTINATION bin, BUNDLE DESTINATION Applications)
+install(TARGETS sushi RUNTIME DESTINATION bin BUNDLE DESTINATION Applications)
 foreach(ITEM ${DOC_FILES_INSTALL})
     install(FILES ${ITEM} DESTINATION share/sushi/doc)
 endforeach()


### PR DESCRIPTION
When installing sushi on linux, a new directory is created

```
/usr/bin,
```

sushi is then installed inside this directory:

```
/usr/bin,/sushi
```

Because of this, the yocto build fails with the follwoing error:

```
NOTE: Executing Tasks
ERROR: sushi-1.0-rc1_yocto_build+ac05b9fcd9d95eaded4908c2a1774a85a9d12dbe-r0 do_package: QA Issue: sushi: Files/directories were installed but not shipped in any package:
  /usr/bin
  /usr/bin,/sushi
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
sushi: 2 installed and not shipped files. [installed-vs-shipped]
ERROR: sushi-1.0-rc1_yocto_build+ac05b9fcd9d95eaded4908c2a1774a85a9d12dbe-r0 do_package: Fatal QA errors found, failing task.
ERROR: Logfile of failure stored in: /home/christof/pedalboard-os/yocto/build/tmp/work/cortexa72-elk-linux/sushi/1.0-rc1_yocto_build+ac05b9fcd9d95eaded4908c2a1774a85a9d12dbe-r0/temp/log.do_package.90438
ERROR: Task (/home/christof/pedalboard-os/yocto/layers/meta-elk/recipes-binaries/sushi/sushi_git.bb:do_package) failed with exit code '1'
```