### PR TITLE
Do not include sentry on arm64

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "sushi",
   "version-string": "1.0.0",
-  "homepage" : "https://github.com/elk-audio/sushi",
-  "description" : "Headless plugin host for Elk Audio OS",
+  "homepage": "https://github.com/elk-audio/sushi",
+  "description": "Headless plugin host for Elk Audio OS",
   "dependencies": [
     {
       "name": "grpc",
@@ -16,6 +16,9 @@
     },
     "portaudio",
     "rtmidi",
-    "sentry-native"
+    {
+      "name": "sentry-native",
+      "platform": "!arm64-linux"
+    }
   ]
 }


### PR DESCRIPTION
Sentry install fails on arm64 :

root@ae661b15a8b3:/sushi# cat /sushi/sushi/build/vcpkg-manifest-install.log
Error: sentry-native:arm64-linux@0.5.0 is only supported on 'osx | (!arm & !uwp)'

