### PR TITLE
feat(reactive): multichannel I/O, CV/Gate routing and timing correctness

### DIFF
--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -16,10 +16,22 @@ For the Reactive use-case, we have developed new frontends for audio and MIDI in
 For the Active use-case, there are no such limitations - the full Sushi functionality is available. 
 
 ## The main limitations for the Reactive use-case are currently that:
-* Sushi can only work with stereo audio I/O.
 * Sushi's audio buffer size is set at compile time, using the CMake argument SUSHI_AUDIO_BUFFER_SIZE. But an audio host may have a dynamic buffer-size setting. If the buffer size doesn't match, the host needs to handle that, ensuring Sushi is only ever given audio buffers of the size defined at build-time.
 * MIDI I/O to Sushi from a containing host application is not currently real-time, but asynchronous, meaning MIDI and audio synchronisation is not sample-accurate.
 * For any control commands to be processes by Sushi, it needs to be receiving audio buffers regularly. When no audio callbacks are received, Sushi will also not process and control commands (e.g. those received over gRPC and OSC).
+
+## Configuring audio channel count (Reactive mode)
+
+The Reactive frontend supports configurable N-channel I/O, up to `MAX_FRONTEND_CHANNELS` (16) channels per direction.
+Set the desired counts on `SushiOptions` before calling `new_instance()`:
+
+```c++
+sushi::SushiOptions options;
+options.reactive_audio_inputs  = 10;
+options.reactive_audio_outputs = 10;
+```
+
+The defaults are `2` (stereo) for backwards compatibility. Requesting more than `MAX_FRONTEND_CHANNELS` channels will cause `new_instance()` to return `Status::FAILED_AUDIO_FRONTEND_INITIALIZATION`.
 
 ## Using Sushi as a library
 For using Sushi as a library, you only need to be aware of the header files contained in the include/sushi folder, where Sushi's API is exposed. The internals are hidden away.
@@ -76,8 +88,9 @@ You will need the following fields:
 sushi::SushiOptions _sushi_options;
 std::unique_ptr<sushi::RtController> _rt_controller;
 std::unique_ptr<sushi::Sushi> _sushi;
-sushi::ChunkSampleBuffer _sushi_buffer_in;
-sushi::ChunkSampleBuffer _sushi_buffer_out;
+// Channel counts must match reactive_audio_inputs / reactive_audio_outputs set in _sushi_options.
+sushi::ChunkSampleBuffer _sushi_buffer_in  {_sushi_options.reactive_audio_inputs};
+sushi::ChunkSampleBuffer _sushi_buffer_out {_sushi_options.reactive_audio_outputs};
 ```
 
 ### Starting Reactive Sushi

--- a/include/sushi/rt_controller.h
+++ b/include/sushi/rt_controller.h
@@ -110,6 +110,41 @@ public:
      */
     virtual void notify_interrupted_audio(Time duration) = 0;
 
+    /// For CV and Gate I/O:
+    /////////////////////////////////////////////////////////////
+
+    /**
+     * @brief Set the value of a CV (control voltage) input channel before calling process_audio().
+     *        Maps to Sushi's internal CV routing system.  Must be called from the audio thread.
+     * @param channel CV channel index [0, MAX_ENGINE_CV_IO_PORTS).
+     * @param value   Normalised value in [0.0, 1.0].
+     */
+    virtual void set_cv_input(int channel, float value) = 0;
+
+    /**
+     * @brief Read the value of a CV output channel after process_audio() returns.
+     *        Reflects any CV values produced by Sushi plugins during the last block.
+     * @param channel CV channel index [0, MAX_ENGINE_CV_IO_PORTS).
+     * @return Normalised value in [0.0, 1.0].
+     */
+    [[nodiscard]] virtual float cv_output(int channel) const = 0;
+
+    /**
+     * @brief Set the state of a gate (digital) input line before calling process_audio().
+     *        Maps to Sushi's internal gate routing system.  Must be called from the audio thread.
+     * @param gate  Gate index [0, 32).
+     * @param high  true = gate high, false = gate low.
+     */
+    virtual void set_gate_input(int gate, bool high) = 0;
+
+    /**
+     * @brief Read the state of a gate output line after process_audio() returns.
+     *        Reflects gate values produced by Sushi plugins during the last block.
+     * @param gate Gate index [0, 32).
+     * @return true if the gate is high.
+     */
+    [[nodiscard]] virtual bool gate_output(int gate) const = 0;
+
     /// For MIDI:
     /////////////////////////////////////////////////////////////
 

--- a/include/sushi/sushi.h
+++ b/include/sushi/sushi.h
@@ -253,14 +253,14 @@ struct SushiOptions
     /**
      * Number of audio input channels for the Reactive frontend.
      * Defaults to 2 (stereo) to maintain backwards compatibility.
-     * Must not exceed MAX_FRONTEND_CHANNELS (16).
+     * Must not exceed MAX_REACTIVE_CHANNELS (16).
      */
     int reactive_audio_inputs = 2;
 
     /**
      * Number of audio output channels for the Reactive frontend.
      * Defaults to 2 (stereo) to maintain backwards compatibility.
-     * Must not exceed MAX_FRONTEND_CHANNELS (16).
+     * Must not exceed MAX_REACTIVE_CHANNELS (16).
      */
     int reactive_audio_outputs = 2;
 

--- a/include/sushi/sushi.h
+++ b/include/sushi/sushi.h
@@ -251,6 +251,31 @@ struct SushiOptions
     std::string sentry_dsn = SUSHI_SENTRY_DSN_DEFAULT;
 
     /**
+     * Number of audio input channels for the Reactive frontend.
+     * Defaults to 2 (stereo) to maintain backwards compatibility.
+     * Must not exceed MAX_FRONTEND_CHANNELS (16).
+     */
+    int reactive_audio_inputs = 2;
+
+    /**
+     * Number of audio output channels for the Reactive frontend.
+     * Defaults to 2 (stereo) to maintain backwards compatibility.
+     * Must not exceed MAX_FRONTEND_CHANNELS (16).
+     */
+    int reactive_audio_outputs = 2;
+
+    /**
+     * Output latency of the audio hardware, in microseconds, for the Reactive frontend.
+     * Defaults to 0. Setting this correctly allows the engine to compensate scheduled
+     * parameter automation and MIDI for the time it takes audio to travel through the
+     * DAC pipeline to a physical output.
+     *
+     * On a typical embedded host, a reasonable estimate is two block periods:
+     *   reactive_output_latency_us = (2 * block_size * 1'000'000) / sample_rate
+     */
+    int reactive_output_latency_us = 0;
+
+    /**
      * These are used only if Sushi uses an Offline audio frontend.
      * Then, sushi uses the first path as its audio input,
      * and the second as output.

--- a/src/audio_frontends/base_audio_frontend.h
+++ b/src/audio_frontends/base_audio_frontend.h
@@ -24,7 +24,7 @@
 
 namespace sushi::internal::audio_frontend {
 
-constexpr int MAX_FRONTEND_CHANNELS = 8;
+constexpr int MAX_FRONTEND_CHANNELS = 16;
 
 /**
  * @brief Error codes returned from init()
@@ -93,6 +93,15 @@ public:
      */
      virtual void pause(bool paused);
 
+    /**
+     * @brief Called by the Sushi instance when the host changes the sample rate after init.
+     *        Updates the internal _sample_rate / _inv_sample_rate used by xrun detection.
+     */
+    virtual void update_sample_rate(float sample_rate)
+    {
+        _set_engine_sample_rate(sample_rate);
+    }
+
 protected:
     /**
      * @brief Call before calling engine->process_chunk for default handling of resume and xrun detection
@@ -125,8 +134,8 @@ protected:
     Time _pause_start;
 
     Time _last_process_time{Time(0)};
-    float _sample_rate;
-    float _inv_sample_rate;
+    float _sample_rate    {44100.0f};
+    float _inv_sample_rate{1.0f / 44100.0f};
 };
 
 } // end namespace sushi::internal

--- a/src/audio_frontends/base_audio_frontend.h
+++ b/src/audio_frontends/base_audio_frontend.h
@@ -24,7 +24,7 @@
 
 namespace sushi::internal::audio_frontend {
 
-constexpr int MAX_FRONTEND_CHANNELS = 16;
+constexpr int MAX_FRONTEND_CHANNELS = 8;
 
 /**
  * @brief Error codes returned from init()

--- a/src/audio_frontends/reactive_frontend.cpp
+++ b/src/audio_frontends/reactive_frontend.cpp
@@ -23,6 +23,7 @@
 #include "elklog/static_logger.h"
 
 #include "reactive_frontend.h"
+#include "audio_frontend_internals.h"
 
 namespace sushi::internal::audio_frontend {
 
@@ -38,7 +39,17 @@ AudioFrontendStatus ReactiveFrontend::init(BaseAudioFrontendConfiguration* confi
 
     auto frontend_config = static_cast<ReactiveFrontendConfiguration*>(_config); // static cast because of no rtti
 
-    _engine->set_audio_channels(REACTIVE_FRONTEND_CHANNELS, REACTIVE_FRONTEND_CHANNELS);
+    if (frontend_config->audio_inputs > MAX_FRONTEND_CHANNELS ||
+        frontend_config->audio_outputs > MAX_FRONTEND_CHANNELS)
+    {
+        ELKLOG_LOG_ERROR("Requested channel count ({} in / {} out) exceeds MAX_FRONTEND_CHANNELS ({})",
+                         frontend_config->audio_inputs,
+                         frontend_config->audio_outputs,
+                         MAX_FRONTEND_CHANNELS);
+        return AudioFrontendStatus::INVALID_N_CHANNELS;
+    }
+
+    _engine->set_audio_channels(frontend_config->audio_inputs, frontend_config->audio_outputs);
 
     auto status = _engine->set_cv_input_channels(frontend_config->cv_inputs);
     if (status != engine::EngineReturnStatus::OK)
@@ -54,7 +65,7 @@ AudioFrontendStatus ReactiveFrontend::init(BaseAudioFrontendConfiguration* confi
         return AudioFrontendStatus::AUDIO_HW_ERROR;
     }
 
-    _engine->set_output_latency(std::chrono::microseconds(0));
+    _engine->set_output_latency(std::chrono::microseconds(frontend_config->output_latency_us));
 
     return ret_code;
 }
@@ -69,21 +80,24 @@ void ReactiveFrontend::run()
     _engine->enable_realtime(true);
 }
 
-// TODO: While in JUCE plugins channel count can change, in sushi it's set on init.
-//  In JUCE, the buffer size is always the same for in and out, with some unused,
-//  if they differ.
+// Note: channel count changes at runtime are not supported — the count is fixed at init().
+// Buffer sizes other than AUDIO_CHUNK_SIZE are the host's responsibility to handle.
 void ReactiveFrontend::process_audio(ChunkSampleBuffer& in_buffer,
                                      ChunkSampleBuffer& out_buffer,
                                      int64_t total_sample_count,
                                      Time timestamp)
 {
-    // TODO: Do we need to concern ourselves with multiple buses?
-
-    // TODO: Deal also with MIDI.
-
-    // TODO: Deal also with CV.
+    // Keep the FTZ/DAZ flags set on x86; no-op on ARM where the compiler/ABI handles it.
+    set_flush_denormals_to_zero();
 
     out_buffer.clear();
+
+    // Automatic xrun detection: compares timestamp against the previous callback.
+    // Fires engine->notify_interrupted_audio() when a gap is detected.
+    // This only has sub-block precision when the host passes real hardware timestamps
+    // (e.g. twine::current_rt_time()) — with calculated timestamps xruns are invisible.
+    // Also handles the resume-after-pause notification path.
+    _handle_resume(timestamp, AUDIO_CHUNK_SIZE);
 
     if (_pause_manager.should_process())
     {
@@ -99,6 +113,10 @@ void ReactiveFrontend::process_audio(ChunkSampleBuffer& in_buffer,
             _pause_manager.ramp_output(out_buffer);
         }
     }
+
+    // Notify the non-RT thread blocked in BaseAudioFrontend::pause(true) once the
+    // output has ramped down.  Without this call, pause() would deadlock.
+    _handle_pause(timestamp);
 }
 
 void ReactiveFrontend::notify_interrupted_audio(Time duration)

--- a/src/audio_frontends/reactive_frontend.cpp
+++ b/src/audio_frontends/reactive_frontend.cpp
@@ -39,13 +39,13 @@ AudioFrontendStatus ReactiveFrontend::init(BaseAudioFrontendConfiguration* confi
 
     auto frontend_config = static_cast<ReactiveFrontendConfiguration*>(_config); // static cast because of no rtti
 
-    if (frontend_config->audio_inputs > MAX_FRONTEND_CHANNELS ||
-        frontend_config->audio_outputs > MAX_FRONTEND_CHANNELS)
+    if (frontend_config->audio_inputs > MAX_REACTIVE_CHANNELS ||
+        frontend_config->audio_outputs > MAX_REACTIVE_CHANNELS)
     {
-        ELKLOG_LOG_ERROR("Requested channel count ({} in / {} out) exceeds MAX_FRONTEND_CHANNELS ({})",
+        ELKLOG_LOG_ERROR("Requested channel count ({} in / {} out) exceeds MAX_REACTIVE_CHANNELS ({})",
                          frontend_config->audio_inputs,
                          frontend_config->audio_outputs,
-                         MAX_FRONTEND_CHANNELS);
+                         MAX_REACTIVE_CHANNELS);
         return AudioFrontendStatus::INVALID_N_CHANNELS;
     }
 

--- a/src/audio_frontends/reactive_frontend.h
+++ b/src/audio_frontends/reactive_frontend.h
@@ -33,6 +33,15 @@
 
 namespace sushi::internal::audio_frontend {
 
+/**
+ * @brief Maximum number of audio channels (each way) supported by the
+ *        Reactive frontend. Kept separate from MAX_FRONTEND_CHANNELS so the
+ *        higher reactive limit does not change the channel/port count of the
+ *        other frontends (e.g. the JACK frontend registers
+ *        MAX_FRONTEND_CHANNELS ports).
+ */
+constexpr int MAX_REACTIVE_CHANNELS = 16;
+
 struct ReactiveFrontendConfiguration : public BaseAudioFrontendConfiguration
 {
     ReactiveFrontendConfiguration(int audio_inputs,

--- a/src/audio_frontends/reactive_frontend.h
+++ b/src/audio_frontends/reactive_frontend.h
@@ -33,17 +33,24 @@
 
 namespace sushi::internal::audio_frontend {
 
-// TODO: Hard-coding the number of channels for now.
-constexpr int REACTIVE_FRONTEND_CHANNELS = 2;
-
 struct ReactiveFrontendConfiguration : public BaseAudioFrontendConfiguration
 {
-    ReactiveFrontendConfiguration(int cv_inputs,
-                                  int cv_outputs) :
-            BaseAudioFrontendConfiguration(cv_inputs, cv_outputs)
+    ReactiveFrontendConfiguration(int audio_inputs,
+                                  int audio_outputs,
+                                  int cv_inputs,
+                                  int cv_outputs,
+                                  int output_latency_us = 0) :
+            BaseAudioFrontendConfiguration(cv_inputs, cv_outputs),
+            audio_inputs{audio_inputs},
+            audio_outputs{audio_outputs},
+            output_latency_us{output_latency_us}
     {}
 
     ~ReactiveFrontendConfiguration() override = default;
+
+    int audio_inputs;
+    int audio_outputs;
+    int output_latency_us;
 };
 
 class ReactiveFrontend : public BaseAudioFrontend
@@ -96,6 +103,47 @@ public:
      * @param duration The length of the interruption
      */
      void notify_interrupted_audio(Time duration);
+
+    /**
+     * @brief Set a CV input value to be passed to the engine in the next process_audio() call.
+     *        Call this before process_audio() from the audio thread.
+     * @param channel Index in [0, MAX_ENGINE_CV_IO_PORTS).
+     * @param value   Normalised value [0.0, 1.0].
+     */
+    void set_cv_input(int channel, float value)
+    {
+        _in_controls.cv_values[static_cast<size_t>(channel)] = value;
+    }
+
+    /**
+     * @brief Read a CV output value produced by the engine during the last process_audio() call.
+     * @param channel Index in [0, MAX_ENGINE_CV_IO_PORTS).
+     * @return Normalised value [0.0, 1.0].
+     */
+    [[nodiscard]] float cv_output(int channel) const
+    {
+        return _out_controls.cv_values[static_cast<size_t>(channel)];
+    }
+
+    /**
+     * @brief Set a gate (digital) input line state before the next process_audio() call.
+     * @param gate  Index in [0, 32).
+     * @param high  true = high, false = low.
+     */
+    void set_gate_input(int gate, bool high)
+    {
+        _in_controls.gate_values.set(static_cast<size_t>(gate), high);
+    }
+
+    /**
+     * @brief Read a gate output state produced by the engine during the last process_audio() call.
+     * @param gate Index in [0, 32).
+     * @return true if the gate is high.
+     */
+    [[nodiscard]] bool gate_output(int gate) const
+    {
+        return _out_controls.gate_values.test(static_cast<size_t>(gate));
+    }
 
 private:
     engine::ControlBuffer _in_controls;

--- a/src/concrete_sushi.cpp
+++ b/src/concrete_sushi.cpp
@@ -209,6 +209,10 @@ control::SushiControl* ConcreteSushi::controller()
 void ConcreteSushi::set_sample_rate(float sample_rate)
 {
     _engine->set_sample_rate(sample_rate);
+    if (_audio_frontend)
+    {
+        _audio_frontend->update_sample_rate(sample_rate);
+    }
 }
 
 float ConcreteSushi::sample_rate() const

--- a/src/engine/controller/real_time_controller.cpp
+++ b/src/engine/controller/real_time_controller.cpp
@@ -115,6 +115,26 @@ void RealTimeController::notify_interrupted_audio(Time duration)
     _audio_frontend->notify_interrupted_audio(duration);
 }
 
+void RealTimeController::set_cv_input(int channel, float value)
+{
+    _audio_frontend->set_cv_input(channel, value);
+}
+
+float RealTimeController::cv_output(int channel) const
+{
+    return _audio_frontend->cv_output(channel);
+}
+
+void RealTimeController::set_gate_input(int gate, bool high)
+{
+    _audio_frontend->set_gate_input(gate, high);
+}
+
+bool RealTimeController::gate_output(int gate) const
+{
+    return _audio_frontend->gate_output(gate);
+}
+
 void RealTimeController::receive_midi(int input, MidiDataByte data, Time timestamp)
 {
     _midi_frontend->receive_midi(input, data, timestamp);
@@ -127,14 +147,36 @@ void RealTimeController::set_midi_callback(ReactiveMidiCallback&& callback)
 
 sushi::Time RealTimeController::calculate_timestamp_from_start(float sample_rate) const
 {
-    uint64_t micros = static_cast<uint64_t>(_samples_since_start * 1'000'000.0f / sample_rate);
-    auto timestamp = std::chrono::microseconds(micros);
-    return timestamp;
+    if (_clock_anchor.count() != 0)
+    {
+        // Host is supplying real hardware timestamps via increment_samples_since_start().
+        // Compute the offset from the anchor in samples and add it to the real clock time.
+        // Using double avoids float precision loss that would occur after ~6 minutes of
+        // session time with a 32-bit float accumulator.
+        int64_t delta_samples = _samples_since_start - _samples_at_anchor;
+        auto delta = std::chrono::microseconds(
+            static_cast<int64_t>(static_cast<double>(delta_samples) * 1'000'000.0 / sample_rate));
+        return _clock_anchor + delta;
+    }
+
+    // Fallback: no real-clock anchor available — derive time purely from the sample counter.
+    // Still uses double to avoid precision loss during long sessions.
+    return std::chrono::microseconds(
+        static_cast<uint64_t>(static_cast<double>(_samples_since_start) * 1'000'000.0 / sample_rate));
 }
 
-void RealTimeController::increment_samples_since_start(int64_t sample_count, Time)
+void RealTimeController::increment_samples_since_start(int64_t sample_count, Time timestamp)
 {
     _samples_since_start += sample_count;
+
+    // If the host provides a real hardware timestamp, record it as the new anchor so that
+    // calculate_timestamp_from_start() can return clock-accurate values.
+    // A zero timestamp means "not provided" and leaves the previous anchor unchanged.
+    if (timestamp.count() != 0)
+    {
+        _clock_anchor      = timestamp;
+        _samples_at_anchor = _samples_since_start;
+    }
 }
 
 } // end namespace sushi

--- a/src/engine/controller/real_time_controller.h
+++ b/src/engine/controller/real_time_controller.h
@@ -78,6 +78,14 @@ public:
 
     void notify_interrupted_audio(sushi::Time duration) override;
 
+    /// For CV and Gate I/O:
+    /////////////////////////////////////////////////////////////
+
+    void set_cv_input(int channel, float value) override;
+    [[nodiscard]] float cv_output(int channel) const override;
+    void set_gate_input(int gate, bool high) override;
+    [[nodiscard]] bool gate_output(int gate) const override;
+
     /// For MIDI:
     /////////////////////////////////////////////////////////////
 
@@ -94,6 +102,15 @@ private:
     midi_frontend::ReactiveMidiFrontend* _midi_frontend {nullptr};
     engine::Transport* _transport {nullptr};
     int64_t _samples_since_start {0};
+
+    // Real-clock anchor for calculate_timestamp_from_start().
+    // Set by increment_samples_since_start() when the host supplies a non-zero
+    // hardware timestamp (e.g. twine::current_rt_time()).  When set, the utility
+    // anchors its output to the real clock instead of a pure sample counter,
+    // which fixes Ableton Link sync and prevents float-precision drift after
+    // long sessions.
+    Time    _clock_anchor {0};
+    int64_t _samples_at_anchor {0};
 
     float _tempo {0};
     sushi::TimeSignature _time_signature {0, 0};

--- a/src/factories/reactive_factory_implementation.cpp
+++ b/src/factories/reactive_factory_implementation.cpp
@@ -69,14 +69,17 @@ std::unique_ptr<RtController> ReactiveFactoryImplementation::rt_controller()
     return std::move(_real_time_controller);
 }
 
-Status ReactiveFactoryImplementation::_setup_audio_frontend([[maybe_unused]] const SushiOptions& options,
+Status ReactiveFactoryImplementation::_setup_audio_frontend(const SushiOptions& options,
                                                             const jsonconfig::ControlConfig& config)
 {
     int cv_inputs = config.cv_inputs.value_or(0);
     int cv_outputs = config.cv_outputs.value_or(0);
 
-    ELKLOG_LOG_INFO("Setting up reactive frontend");
-    _frontend_config = std::make_unique<audio_frontend::ReactiveFrontendConfiguration>(cv_inputs, cv_outputs);
+    ELKLOG_LOG_INFO("Setting up reactive frontend ({} in / {} out)",
+                    options.reactive_audio_inputs, options.reactive_audio_outputs);
+    _frontend_config = std::make_unique<audio_frontend::ReactiveFrontendConfiguration>(
+        options.reactive_audio_inputs, options.reactive_audio_outputs,
+        cv_inputs, cv_outputs, options.reactive_output_latency_us);
 
     _audio_frontend = std::make_unique<audio_frontend::ReactiveFrontend>(_engine.get());
 

--- a/src/factories/reactive_factory_implementation.h
+++ b/src/factories/reactive_factory_implementation.h
@@ -67,7 +67,7 @@ public:
     std::unique_ptr<RtController> rt_controller();
 
 protected:
-    Status _setup_audio_frontend([[maybe_unused]] const SushiOptions& options,
+    Status _setup_audio_frontend(const SushiOptions& options,
                                  const jsonconfig::ControlConfig& config) override;
 
     Status _set_up_midi([[maybe_unused]] const SushiOptions& options,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ SET(TEST_FILES
     unittests/engine/controllers/reactive_controller_test.cpp
     unittests/engine/factories/factories_test.cpp
     unittests/audio_frontends/offline_frontend_test.cpp
+    unittests/audio_frontends/reactive_frontend_test.cpp
     unittests/control_frontends/osc_frontend_test.cpp
     unittests/control_frontends/oscpack_osc_messenger_test.cpp
     unittests/dsp_library/envelope_test.cpp
@@ -67,6 +68,7 @@ SET(TEST_FILES
 set(TEST_HELPER_FILES ${TEST_HELPER_FILES}
     ${PROJECT_SOURCE_DIR}/src/library/processor_state.cpp
     ${PROJECT_SOURCE_DIR}/src/audio_frontends/base_audio_frontend.cpp
+    ${PROJECT_SOURCE_DIR}/src/audio_frontends/reactive_frontend.cpp
     ${PROJECT_SOURCE_DIR}/src/plugins/transposer_plugin.cpp
     ${PROJECT_SOURCE_DIR}/src/library/lv2/lv2_processor_factory.cpp
     ${PROJECT_SOURCE_DIR}/src/library/vst2x/vst2x_processor_factory.cpp

--- a/test/unittests/audio_frontends/reactive_frontend_test.cpp
+++ b/test/unittests/audio_frontends/reactive_frontend_test.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2017-2023 Elk Audio AB
+ *
+ * SUSHI is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * SUSHI is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * SUSHI. If not, see http://www.gnu.org/licenses/
+ */
+
+#include "gtest/gtest.h"
+
+#include "test_utils/engine_mockup.h"
+#include "test_utils/test_utils.h"
+
+#include "elk-warning-suppressor/warning_suppressor.hpp"
+
+#include "audio_frontends/reactive_frontend.h"
+
+using namespace sushi;
+using namespace sushi::internal;
+using namespace sushi::internal::audio_frontend;
+
+constexpr float SAMPLE_RATE = 44100;
+
+// Engine mockup that copies the input ControlBuffer to the output ControlBuffer during
+// process_chunk. Lets us verify that CV / gate values set through set_cv_input() /
+// set_gate_input() reach the engine and that cv_output() / gate_output() reflect
+// anything the engine writes to the output ControlBuffer.
+class CvLoopbackEngineMockup : public EngineMockup
+{
+public:
+    explicit CvLoopbackEngineMockup(float sample_rate) : EngineMockup(sample_rate) {}
+
+    void process_chunk(ChunkSampleBuffer* in_buffer,
+                       ChunkSampleBuffer* out_buffer,
+                       engine::ControlBuffer* in_controls,
+                       engine::ControlBuffer* out_controls,
+                       Time timestamp,
+                       int64_t sample_count) override
+    {
+        EngineMockup::process_chunk(in_buffer, out_buffer, in_controls, out_controls,
+                                    timestamp, sample_count);
+        *out_controls = *in_controls;
+    }
+};
+
+// Engine mockup that records the arguments of set_output_latency() and
+// notify_interrupted_audio() — both are swallowed by the plain EngineMockup.
+class RecordingEngineMockup : public EngineMockup
+{
+public:
+    explicit RecordingEngineMockup(float sample_rate) : EngineMockup(sample_rate) {}
+
+    void set_output_latency(Time latency) override
+    {
+        output_latency = latency;
+    }
+
+    void notify_interrupted_audio(Time duration) override
+    {
+        interruption_notified = true;
+        interruption_duration = duration;
+    }
+
+    Time output_latency {0};
+    bool interruption_notified {false};
+    Time interruption_duration {0};
+};
+
+class TestReactiveFrontend : public ::testing::Test
+{
+protected:
+    TestReactiveFrontend() = default;
+
+    void SetUp() override
+    {
+        _module_under_test = std::make_unique<ReactiveFrontend>(&_engine);
+    }
+
+    EngineMockup _engine {SAMPLE_RATE};
+    std::unique_ptr<ReactiveFrontend> _module_under_test;
+};
+
+TEST_F(TestReactiveFrontend, TestInitConfiguresChannelsAndLatency)
+{
+    ReactiveFrontendConfiguration config(/*audio_in*/ 4, /*audio_out*/ 8,
+                                         /*cv_in*/ 2, /*cv_out*/ 1,
+                                         /*output_latency_us*/ 1500);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    EXPECT_EQ(4, _engine.audio_input_channels());
+    EXPECT_EQ(8, _engine.audio_output_channels());
+    EXPECT_EQ(2, _engine.cv_input_channels());
+    EXPECT_EQ(1, _engine.cv_output_channels());
+}
+
+TEST_F(TestReactiveFrontend, TestInitAcceptsMaxChannels)
+{
+    ReactiveFrontendConfiguration config(MAX_FRONTEND_CHANNELS, MAX_FRONTEND_CHANNELS, 0, 0);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    EXPECT_EQ(MAX_FRONTEND_CHANNELS, _engine.audio_input_channels());
+    EXPECT_EQ(MAX_FRONTEND_CHANNELS, _engine.audio_output_channels());
+}
+
+TEST_F(TestReactiveFrontend, TestInitRejectsTooManyInputChannels)
+{
+    ReactiveFrontendConfiguration config(MAX_FRONTEND_CHANNELS + 1, 2, 0, 0);
+    EXPECT_EQ(AudioFrontendStatus::INVALID_N_CHANNELS, _module_under_test->init(&config));
+}
+
+TEST_F(TestReactiveFrontend, TestInitRejectsTooManyOutputChannels)
+{
+    ReactiveFrontendConfiguration config(2, MAX_FRONTEND_CHANNELS + 1, 0, 0);
+    EXPECT_EQ(AudioFrontendStatus::INVALID_N_CHANNELS, _module_under_test->init(&config));
+}
+
+TEST_F(TestReactiveFrontend, TestUpdateSampleRatePropagatesToEngine)
+{
+    ReactiveFrontendConfiguration config(2, 2, 0, 0);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    _module_under_test->update_sample_rate(48000.0f);
+    EXPECT_FLOAT_EQ(48000.0f, _engine.sample_rate());
+}
+
+TEST_F(TestReactiveFrontend, TestProcessAudioClearsOutputAndCallsEngine)
+{
+    ReactiveFrontendConfiguration config(2, 2, 0, 0);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    ChunkSampleBuffer in_buffer(2);
+    ChunkSampleBuffer out_buffer(2);
+    test_utils::fill_sample_buffer(in_buffer, 0.25f);
+    test_utils::fill_sample_buffer(out_buffer, -1.0f);  // garbage the frontend must clear
+
+    ASSERT_FALSE(_engine.process_called);
+    _module_under_test->process_audio(in_buffer, out_buffer, 0, std::chrono::microseconds(0));
+    ASSERT_TRUE(_engine.process_called);
+
+    // EngineMockup's process_chunk copies in → out, so after clear+process we see the input.
+    test_utils::assert_buffer_value(0.25f, out_buffer);
+}
+
+class TestReactiveFrontendCv : public ::testing::Test
+{
+protected:
+    TestReactiveFrontendCv() = default;
+
+    void SetUp() override
+    {
+        _module_under_test = std::make_unique<ReactiveFrontend>(&_engine);
+        ReactiveFrontendConfiguration config(2, 2, 2, 2);
+        ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+    }
+
+    CvLoopbackEngineMockup _engine {SAMPLE_RATE};
+    std::unique_ptr<ReactiveFrontend> _module_under_test;
+};
+
+TEST_F(TestReactiveFrontendCv, TestCvInputReachesEngineAndCvOutputIsReadable)
+{
+    _module_under_test->set_cv_input(0, 0.75f);
+    _module_under_test->set_cv_input(1, 0.125f);
+
+    ChunkSampleBuffer in_buffer(2);
+    ChunkSampleBuffer out_buffer(2);
+    _module_under_test->process_audio(in_buffer, out_buffer, 0, std::chrono::microseconds(0));
+
+    // The loopback engine forwards in_controls to out_controls, so cv_output() should
+    // now reflect what we wrote with set_cv_input().
+    EXPECT_FLOAT_EQ(0.75f,  _module_under_test->cv_output(0));
+    EXPECT_FLOAT_EQ(0.125f, _module_under_test->cv_output(1));
+}
+
+TEST_F(TestReactiveFrontendCv, TestGateInputReachesEngineAndGateOutputIsReadable)
+{
+    _module_under_test->set_gate_input(0, true);
+    _module_under_test->set_gate_input(3, true);
+    _module_under_test->set_gate_input(7, false);
+
+    ChunkSampleBuffer in_buffer(2);
+    ChunkSampleBuffer out_buffer(2);
+    _module_under_test->process_audio(in_buffer, out_buffer, 0, std::chrono::microseconds(0));
+
+    EXPECT_TRUE (_module_under_test->gate_output(0));
+    EXPECT_TRUE (_module_under_test->gate_output(3));
+    EXPECT_FALSE(_module_under_test->gate_output(7));
+    EXPECT_FALSE(_module_under_test->gate_output(15));  // never written
+}
+
+class TestReactiveFrontendRecording : public ::testing::Test
+{
+protected:
+    TestReactiveFrontendRecording() = default;
+
+    void SetUp() override
+    {
+        _module_under_test = std::make_unique<ReactiveFrontend>(&_engine);
+    }
+
+    RecordingEngineMockup _engine {SAMPLE_RATE};
+    std::unique_ptr<ReactiveFrontend> _module_under_test;
+};
+
+TEST_F(TestReactiveFrontendRecording, TestInitForwardsOutputLatencyToEngine)
+{
+    ReactiveFrontendConfiguration config(2, 2, 0, 0, /*output_latency_us*/ 2900);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    EXPECT_EQ(std::chrono::microseconds(2900), _engine.output_latency);
+}
+
+TEST_F(TestReactiveFrontendRecording, TestInitDefaultLatencyIsZero)
+{
+    ReactiveFrontendConfiguration config(2, 2, 0, 0);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    EXPECT_EQ(std::chrono::microseconds(0), _engine.output_latency);
+}
+
+TEST_F(TestReactiveFrontendRecording, TestNotifyInterruptedAudioForwardsToEngine)
+{
+    ReactiveFrontendConfiguration config(2, 2, 0, 0);
+    ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
+
+    ASSERT_FALSE(_engine.interruption_notified);
+
+    auto duration = std::chrono::milliseconds(42);
+    _module_under_test->notify_interrupted_audio(duration);
+
+    EXPECT_TRUE(_engine.interruption_notified);
+    EXPECT_EQ(std::chrono::duration_cast<Time>(duration), _engine.interruption_duration);
+}

--- a/test/unittests/audio_frontends/reactive_frontend_test.cpp
+++ b/test/unittests/audio_frontends/reactive_frontend_test.cpp
@@ -102,22 +102,22 @@ TEST_F(TestReactiveFrontend, TestInitConfiguresChannelsAndLatency)
 
 TEST_F(TestReactiveFrontend, TestInitAcceptsMaxChannels)
 {
-    ReactiveFrontendConfiguration config(MAX_FRONTEND_CHANNELS, MAX_FRONTEND_CHANNELS, 0, 0);
+    ReactiveFrontendConfiguration config(MAX_REACTIVE_CHANNELS, MAX_REACTIVE_CHANNELS, 0, 0);
     ASSERT_EQ(AudioFrontendStatus::OK, _module_under_test->init(&config));
 
-    EXPECT_EQ(MAX_FRONTEND_CHANNELS, _engine.audio_input_channels());
-    EXPECT_EQ(MAX_FRONTEND_CHANNELS, _engine.audio_output_channels());
+    EXPECT_EQ(MAX_REACTIVE_CHANNELS, _engine.audio_input_channels());
+    EXPECT_EQ(MAX_REACTIVE_CHANNELS, _engine.audio_output_channels());
 }
 
 TEST_F(TestReactiveFrontend, TestInitRejectsTooManyInputChannels)
 {
-    ReactiveFrontendConfiguration config(MAX_FRONTEND_CHANNELS + 1, 2, 0, 0);
+    ReactiveFrontendConfiguration config(MAX_REACTIVE_CHANNELS + 1, 2, 0, 0);
     EXPECT_EQ(AudioFrontendStatus::INVALID_N_CHANNELS, _module_under_test->init(&config));
 }
 
 TEST_F(TestReactiveFrontend, TestInitRejectsTooManyOutputChannels)
 {
-    ReactiveFrontendConfiguration config(2, MAX_FRONTEND_CHANNELS + 1, 0, 0);
+    ReactiveFrontendConfiguration config(2, MAX_REACTIVE_CHANNELS + 1, 0, 0);
     EXPECT_EQ(AudioFrontendStatus::INVALID_N_CHANNELS, _module_under_test->init(&config));
 }
 

--- a/test/unittests/engine/controllers/reactive_controller_test.cpp
+++ b/test/unittests/engine/controllers/reactive_controller_test.cpp
@@ -23,7 +23,7 @@
 
 #include "engine/controller/real_time_controller.cpp"
 
-#include "audio_frontends/reactive_frontend.cpp"
+#include "audio_frontends/reactive_frontend.h"
 #include "control_frontends/reactive_midi_frontend.cpp"
 
 #include "test_utils/audio_frontend_mockup.h"
@@ -55,6 +55,21 @@ public:
     [[nodiscard]] control::PlayingMode playing_mode() const
     {
         return _friend._playing_mode;
+    }
+
+    [[nodiscard]] sushi::Time clock_anchor() const
+    {
+        return _friend._clock_anchor;
+    }
+
+    [[nodiscard]] int64_t samples_at_anchor() const
+    {
+        return _friend._samples_at_anchor;
+    }
+
+    [[nodiscard]] int64_t samples_since_start() const
+    {
+        return _friend._samples_since_start;
     }
 
 private:
@@ -198,4 +213,80 @@ TEST_F(ReactiveControllerTestFrontend, TestRtControllerMidiCalls)
 {
     // TODO: Currently the Passive Controller MIDI handling over the Passive MIDI frontend, is unfinished,
     //  and not real-time safe. Once it's finished (story AUD-456), we should add relevant tests also here.
+}
+
+TEST_F(ReactiveControllerTestFrontend, TestTimestampFallsBackToSampleCounterWithoutAnchor)
+{
+    // With no hardware timestamp supplied, calculate_timestamp_from_start() should derive
+    // time purely from the sample counter.
+    _real_time_controller->increment_samples_since_start(44100, Time(0));
+
+    EXPECT_EQ(_accessor->clock_anchor(), Time(0));
+    EXPECT_EQ(_accessor->samples_at_anchor(), 0);
+
+    auto ts = _real_time_controller->calculate_timestamp_from_start(TEST_SAMPLE_RATE);
+    EXPECT_EQ(ts, std::chrono::microseconds(1'000'000));
+}
+
+TEST_F(ReactiveControllerTestFrontend, TestTimestampAnchorsToRealClockWhenProvided)
+{
+    // Supplying a non-zero timestamp anchors the utility to the real clock. Subsequent calls
+    // with zero timestamps keep the anchor intact and extrapolate from the sample counter.
+    auto anchor = std::chrono::microseconds(5'000'000);
+    _real_time_controller->increment_samples_since_start(44100, anchor);
+
+    EXPECT_EQ(_accessor->clock_anchor(), anchor);
+    EXPECT_EQ(_accessor->samples_at_anchor(), 44100);
+
+    // Exactly at the anchor, timestamp == anchor.
+    EXPECT_EQ(_real_time_controller->calculate_timestamp_from_start(TEST_SAMPLE_RATE), anchor);
+
+    // One second of audio later, with no new hardware timestamp, extrapolate from the sample
+    // counter delta.
+    _real_time_controller->increment_samples_since_start(44100, Time(0));
+    EXPECT_EQ(_accessor->clock_anchor(), anchor);  // anchor unchanged
+    EXPECT_EQ(_real_time_controller->calculate_timestamp_from_start(TEST_SAMPLE_RATE),
+              anchor + std::chrono::microseconds(1'000'000));
+}
+
+TEST_F(ReactiveControllerTestFrontend, TestTimestampReanchorsOnNewHardwareTimestamp)
+{
+    _real_time_controller->increment_samples_since_start(44100, std::chrono::microseconds(1'000'000));
+
+    // A new hardware timestamp re-anchors.
+    auto new_anchor = std::chrono::microseconds(10'000'000);
+    _real_time_controller->increment_samples_since_start(44100, new_anchor);
+
+    EXPECT_EQ(_accessor->clock_anchor(), new_anchor);
+    EXPECT_EQ(_accessor->samples_at_anchor(), 88200);
+    EXPECT_EQ(_real_time_controller->calculate_timestamp_from_start(TEST_SAMPLE_RATE), new_anchor);
+}
+
+TEST_F(ReactiveControllerTestFrontend, TestTimestampRemainsExactOverLongSession)
+{
+    // The utility stores the sample count in int64_t and does the µs conversion in
+    // double.  The earlier float-based implementation drifted by > 1 ms after a few
+    // minutes — this test locks in the current precision contract.
+    //
+    // 1 hour at 44.1 kHz = 158'760'000 samples → 3'600'000'000 µs exactly.
+    const int64_t one_hour_samples = static_cast<int64_t>(TEST_SAMPLE_RATE) * 3600;
+
+    // Anchored at t=0 so the utility uses the anchored path.
+    _real_time_controller->increment_samples_since_start(0, std::chrono::microseconds(0));
+    _real_time_controller->increment_samples_since_start(one_hour_samples, Time(0));
+
+    EXPECT_EQ(_real_time_controller->calculate_timestamp_from_start(TEST_SAMPLE_RATE),
+              std::chrono::microseconds(3'600'000'000LL));
+}
+
+TEST_F(ReactiveControllerTestFrontend, TestTimestampRemainsExactWithoutAnchorOverLongSession)
+{
+    // Same contract for the unanchored fallback path, which runs when the host never
+    // passes a real timestamp via increment_samples_since_start().
+    const int64_t one_hour_samples = static_cast<int64_t>(TEST_SAMPLE_RATE) * 3600;
+    _real_time_controller->increment_samples_since_start(one_hour_samples, Time(0));
+
+    EXPECT_EQ(_accessor->clock_anchor(), Time(0));  // confirm we stayed on the fallback path
+    EXPECT_EQ(_real_time_controller->calculate_timestamp_from_start(TEST_SAMPLE_RATE),
+              std::chrono::microseconds(3'600'000'000LL));
 }


### PR DESCRIPTION
Extends the Reactive (embedded host) frontend beyond stereo and fixes timestamp correctness in the RealTimeController.

Frontend & configuration
  - ReactiveFrontendConfiguration takes audio_inputs, audio_outputs and output_latency_us (defaults stay at stereo / 0 us for backwards compat).
  - MAX_FRONTEND_CHANNELS raised from 8 to 16; over-max returns INVALID_N_CHANNELS.
  - ReactiveFrontend::process_audio() now runs xrun detection, pause-ramp handling, and set_flush_denormals_to_zero().
  - SushiOptions exposes reactive_audio_inputs, reactive_audio_outputs, reactive_output_latency_us.

CV / Gate routing
  - RtController gains set_cv_input / cv_output / set_gate_input / gate_output, forwarded to the frontend's ControlBuffer.

Timestamp correctness
  - calculate_timestamp_from_start() anchors to the host's real clock when a hardware timestamp is supplied via increment_samples_since_start(); prevents float-precision drift in long sessions and fixes Link sync (int64_t + double math).

Sample-rate propagation
  - ConcreteSushi::set_sample_rate() propagates to the frontend through a new BaseAudioFrontend::update_sample_rate() hook.

Tests
  - reactive_frontend_test.cpp: channel bounds, output latency, CV/Gate round-trip, update_sample_rate, notify_interrupted_audio forwarding.
  - reactive_controller_test.cpp: clock-anchor behaviour and long-session precision guards.

Manually tested on a Bela Gem Multi through a minimal Bela C++ project that uses Sushi Reactive frontend.

Sample Bela C++ code :

```c++
#include <Bela.h>
#include <cstring>
#include <cstdlib>
#include <cstdio>
#include <string>

#define TWINE_EXPOSE_INTERNALS  // init_xenomai() is host-only API, hidden by default
#include <twine/twine.h>

#include <sushi/constants.h>
#include <sushi/reactive_factory.h>
#include <sushi/rt_controller.h>
#include <sushi/sample_buffer.h>
#include <sushi/sushi.h>

static std::unique_ptr<sushi::Sushi> g_sushi;
static std::unique_ptr<sushi::RtController> g_rt;

// Channel mapping: sushi channels 0/1 <-> Bela audio codec, channels 2..9 <->
// Bela analog I/O 0..7 (capelet, unipolar DAC: signals are re-biased 0.5+/-0.5
// on output). SUSHI_IO_CHANNELS env (2..10, default 2) sets the count at
// startup — the default is bit-identical to the historical stereo behaviour.
static int g_channels = 2;
static sushi::ChunkSampleBuffer g_in;
static sushi::ChunkSampleBuffer g_out;


bool setup(BelaContext* context, void* /*userData*/)
{
    // Arm twine's realtime flag so WorkerPool::create_worker_pool() returns the
    // EVL out-of-band pool (otherwise it silently falls back to plain pthreads
    // pinned to cores 0..N-1, ignoring isolcpus).
    twine::init_xenomai();

    sushi::ReactiveFactory factory;

    sushi::SushiOptions options;
    options.frontend_type = sushi::FrontendType::REACTIVE;
    options.config_source = sushi::ConfigurationSource::FILE;
    const char* config_env = std::getenv("SUSHI_CONFIG");
    const char* plugin_env = std::getenv("SUSHI_PLUGIN_PATH");
    const char* log_env    = std::getenv("SUSHI_LOG_LEVEL");
    const char* cores_env  = std::getenv("SUSHI_RT_CORES");
    const char* chans_env  = std::getenv("SUSHI_IO_CHANNELS");
    int rt_cores = cores_env ? std::atoi(cores_env) : 1;
    if (rt_cores < 1 || rt_cores > 3)
    {
        rt_cores = 1;
    }
    g_channels = chans_env ? std::atoi(chans_env) : 2;
    if (g_channels < 2 || g_channels > 10)
    {
        g_channels = 2;
    }
    options.config_filename = config_env ? config_env : "/root/sushi-config.json";
    options.base_plugin_path = plugin_env ? plugin_env : "/usr/lib/vst3";
    options.use_osc = false;
    options.use_grpc = true;
    options.log_level = log_env ? log_env : "warning";
    options.log_file = "/tmp/sushi.log";
    options.rt_cpu_cores = rt_cores;
    options.enable_timings = true;
    options.reactive_audio_inputs = g_channels;
    options.reactive_audio_outputs = g_channels;

    auto [sushi, status] = factory.new_instance(options);
    if (status != sushi::Status::OK)
    {
        rt_fprintf(stderr, "nexus-preamp: sushi init failed: %s\n",
                   sushi::to_string(status).c_str());
        return false;
    }

    g_rt = factory.rt_controller();
    if (!g_rt)
    {
        rt_fprintf(stderr, "nexus-preamp: failed to get RtController\n");
        return false;
    }

    sushi->set_sample_rate(context->audioSampleRate);

    auto start_status = sushi->start();
    if (start_status != sushi::Status::OK)
    {
        rt_fprintf(stderr, "nexus-preamp: sushi start failed: %s\n",
                   sushi::to_string(start_status).c_str());
        return false;
    }

    g_sushi = std::move(sushi);

    g_in = sushi::ChunkSampleBuffer(g_channels);
    g_out = sushi::ChunkSampleBuffer(g_channels);

    rt_fprintf(stderr,
               "nexus-preamp: bela ctx — audio %u in/%u out @%g Hz (%u frames), analog %u in/%u out (%u frames)\n",
               context->audioInChannels, context->audioOutChannels,
               context->audioSampleRate, context->audioFrames,
               context->analogInChannels, context->analogOutChannels,
               context->analogFrames);

    rt_fprintf(stderr, "nexus-preamp: sushi started (gRPC on :51051, rt_cores=%d, chunk=%d, io_channels=%d)\n",
               rt_cores, sushi::AUDIO_CHUNK_SIZE, g_channels);

    return true;
}

void render(BelaContext* context, void* /*userData*/)
{
    const int frames = context->audioFrames;
    constexpr int chunk = sushi::AUDIO_CHUNK_SIZE;

    // The engine consumes exactly AUDIO_CHUNK_SIZE frames per process_audio()
    // call; feeding it any other amount corrupts memory or desyncs time.
    if (frames % chunk != 0)
    {
        static bool warned = false;
        if (!warned)
        {
            rt_fprintf(stderr, "nexus-preamp: period %d incompatible with sushi chunk %d — muting\n",
                       frames, chunk);
            warned = true;
        }
        for (int ch = 0; ch < 2; ch++)
        {
            for (int n = 0; n < frames; n++)
            {
                audioWrite(context, n, ch, 0.0f);
            }
        }
        return;
    }

    // Two possible Bela layouts for the extra channels:
    //  - classic: separate analog context (analogRead/Write, often half rate)
    //  - PB2 multichannel codec: extra channels folded into the AUDIO context
    //    (audioOutChannels > 2) — then audioWrite reaches them directly.
    const int audio_in_ch = static_cast<int>(context->audioInChannels);
    const int audio_out_ch = static_cast<int>(context->audioOutChannels);
    const int analog_frames = context->analogFrames;
    const int analog_ratio = (analog_frames > 0) ? frames / analog_frames : 1;
    const int analog_in = static_cast<int>(context->analogInChannels);
    const int analog_out = static_cast<int>(context->analogOutChannels);

    for (int offset = 0; offset < frames; offset += chunk)
    {
        for (int ch = 0; ch < g_channels; ch++)
        {
            float* dst = g_in.channel(ch);
            if (ch < audio_in_ch)
            {
                for (int n = 0; n < chunk; n++)
                {
                    dst[n] = audioRead(context, offset + n, ch);
                }
            }
            else if (ch - 2 < analog_in)
            {
                // Unipolar ADC 0..1 -> bipolar
                for (int n = 0; n < chunk; n++)
                {
                    dst[n] = 2.0f * analogRead(context, (offset + n) / analog_ratio, ch - 2) - 1.0f;
                }
            }
            else
            {
                std::memset(dst, 0, chunk * sizeof(float));
            }
        }

        auto timestamp = g_rt->calculate_timestamp_from_start(context->audioSampleRate);
        g_rt->process_audio(g_in, g_out, timestamp);
        g_rt->increment_samples_since_start(chunk, timestamp);

        for (int ch = 0; ch < g_channels; ch++)
        {
            const float* src = g_out.channel(ch);
            if (ch < audio_out_ch)
            {
                for (int n = 0; n < chunk; n++)
                {
                    audioWrite(context, offset + n, ch, src[n]);
                }
            }
            else if (ch - 2 < analog_out)
            {
                // Bipolar -> unipolar DAC, clamped to 0..1
                for (int n = 0; n < chunk; n++)
                {
                    float v = 0.5f + 0.5f * src[n];
                    v = (v < 0.0f) ? 0.0f : (v > 1.0f ? 1.0f : v);
                    analogWriteOnce(context, (offset + n) / analog_ratio, ch - 2, v);
                }
            }
        }
    }
}

void cleanup(BelaContext* /*context*/, void* /*userData*/)
{
    if (g_sushi)
    {
        g_sushi->stop();
        g_sushi.reset();
    }
    g_rt.reset();
}
```